### PR TITLE
Undefined name: x --> x0

### DIFF
--- a/pymatting/solver/cg.py
+++ b/pymatting/solver/cg.py
@@ -33,7 +33,7 @@ def cg(
     elif callable(M):
         precondition = M
     else:
-        precondition = M.dot(x)
+        precondition = M.dot(x0)
 
     x = np.zeros_like(b) if x0 is None else x0.copy()
 


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/pymatting/pymatting on Python 3.8.0

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./pymatting/solver/cg.py:36:30: F821 undefined name 'x'
        precondition = M.dot(x)
                             ^
1     F821 undefined name 'x'
1
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.