### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.md


### PR DESCRIPTION
This bundles in `LICENSE.md` in the sdist tar in PyPI. Context: I'm trying to get this package onto conda-forge and they require the license file to be bundled into the sdist.