### PR TITLE
Upgrade GitHub Actions and lint with codespell and ruff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,19 +12,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8
-        pip install -r requirements.txt
-    - name: Lint with flake8
+    - uses: actions/checkout@v3
+    - run: pip install --user codespell[toml] ruff
+    - run: codespell --skip="*.bib"
+    - name: Lint with ruff
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        ruff . --format=github --line-length=332 --select=E501,E9,F63,F7,F82 --target-version=py38
+        # exit-zero treats all errors as warnings
+        ruff . --exit-zero --line-length=332 --statistics

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,17 +10,18 @@ jobs:
   build:
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.11
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ### 1.1.1
 
-- Compile on first import instead of during build to simplfy PyPI upload process.
+- Compile on first import instead of during build to simplify PyPI upload process.
 
 ### 1.1.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,13 +3,13 @@
 ## Bug Reports
 For bug reports please open a new issue. Include a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) and state your operating system, as well as the versions of all relevant Python packages you are using.
 
-**Important:** Before opening a new issue, make sure to check wether a similar issue already exists.
+**Important:** Before opening a new issue, make sure to check whether a similar issue already exists.
 
 ## Questions
 
 If you have any other questions about the usage of the library feel free to open an issue or chat with us on [gitter](https://gitter.im/pymatting/community).
 
-**Important:** Before opening a new issue, make sure to check wether a similar issue already exists.
+**Important:** Before opening a new issue, make sure to check whether a similar issue already exists.
 
 ## Contributing Source Code
 

--- a/benchmarks/solve_petsc.c
+++ b/benchmarks/solve_petsc.c
@@ -89,7 +89,7 @@ int solve_petsc_coo(
     
     ierr = VecSetValues(b, n, indices, rhs, INSERT_VALUES);CHKERRQ(ierr);
 
-    // inizialize Krylov subspace solver
+    // initialize Krylov subspace solver
     ierr = KSPCreate(PETSC_COMM_WORLD,&ksp);CHKERRQ(ierr);
     ierr = KSPSetOperators(ksp,A,A);CHKERRQ(ierr);
     // should be preconditioned conjugate gradient descent

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -30,7 +30,7 @@ To estimate the alpha matte Pymatting implements the following methods:
 Foreground Extraction
 ---------------------
 
-Simply multiplying the alpha matte with the input image results in halo artifacts. This motivates the developement of foreground extraction methods.
+Simply multiplying the alpha matte with the input image results in halo artifacts. This motivates the development of foreground extraction methods.
 
 .. figure:: figures/lemur_color_bleeding.png
    :align: center

--- a/pymatting/laplacian/lkm_laplacian.py
+++ b/pymatting/laplacian/lkm_laplacian.py
@@ -22,7 +22,7 @@ def lkm_laplacian(image, epsilon=1e-7, radius=10, return_diagonal=True):
     L_matvec: function
         Function that applies the Laplacian matrix to a vector
     diag_L: numpy.ndarray
-        Diagonal entries of the matting Laplacian, only returnes if `return_diagonal` is True
+        Diagonal entries of the matting Laplacian, only returns if `return_diagonal` is True
     """
     image = image.astype(np.float64)
 

--- a/pymatting/solver/cg.py
+++ b/pymatting/solver/cg.py
@@ -31,7 +31,7 @@ def cg(
     M: function or scipy.sparse.csr_matrix
        Function that applies the preconditioner to a vector. Alternatively, `M` can be a matrix describing the precondioner.
     reorthogonalize: boolean
-        Wether to apply reorthogonalization of the residuals after each update, defaults to `False`
+        Whether to apply reorthogonalization of the residuals after each update, defaults to `False`
 
 
     Returns

--- a/pymatting/util/util.py
+++ b/pymatting/util/util.py
@@ -196,7 +196,7 @@ def isiterable(obj):
     Returns
     -------
     is_iterable: bool
-        Boolean variable indicating wether the object is iterable
+        Boolean variable indicating whether the object is iterable
 
     Example
     -------
@@ -759,7 +759,7 @@ def grid_coordinates(width, height, flatten=False):
 def sparse_conv_matrix_with_offsets(width, height, kernel, dx, dy):
     """Calculates a convolution matrix that can be applied to a vectorized image
 
-    Additionaly, this function allows to specify which pixels should be used for the convoltion, i.e.
+    Additionally, this function allows to specify which pixels should be used for the convoltion, i.e.
 
     .. math:: \\left(I * K\\right)_{ij} = \\sum_k K_k I_{i+{\\Delta_y}_k,j+{\\Delta_y}_k},
 


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

`ruff --format=github` rapidly provides intuitive GitHub Annotations to contributors.