### PR TITLE
fix escape sequences in docstring

### DIFF
--- a/pymatting/laplacian/laplacian.py
+++ b/pymatting/laplacian/laplacian.py
@@ -6,13 +6,13 @@ def make_linear_system(L, trimap, lambda_value=100.0, return_c=False):
     """This function constructs a linear system from a matting Laplacian by
     constraining the foreground and background pixels with a diagonal matrix
     `C` to values in the right-hand-side vector `b`. The constraints are
-    weighted by a factor :math:`\lambda`. The linear system is given as
+    weighted by a factor :math:`\\lambda`. The linear system is given as
 
     .. math::
 
-      A = L + \lambda C,
+      A = L + \\lambda C,
 
-    where :math:`C=\mathop{Diag}(c)` having :math:`c_i = 1` if pixel i is known
+    where :math:`C=\\mathop{Diag}(c)` having :math:`c_i = 1` if pixel i is known
     and :math:`c_i = 0` otherwise.
     The right-hand-side :math:`b` is a vector with entries :math:`b_i = 1` is
     pixel is is a foreground pixel and :math:`b_i = 0` otherwise.


### PR DESCRIPTION
This fixes the following issue:

    SyntaxWarning: invalid escape sequence '\l'